### PR TITLE
Added the CLI option words_file to the CLI and API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ To interact with the server, you first need to run it:
 
     go run http/api.go
 
-After having the server up and running you can start to talk to the API. 
+After having the server up and running you can start to talk to the API.
+
+To specify a words file you want to load, you can use the `-words_file` command line option:
+
+    go run http/api.go -words_file=/path/to/my/file.txt
 
 ### Starting a new game:
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -2,8 +2,9 @@ package cli
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
-	"go-hangman/game"
+	hangman "go-hangman/game"
 	"log"
 	"os"
 	"strings"
@@ -29,13 +30,23 @@ func initializeGame(turnsLeft int, word string) hangman.Game {
 
 // Play : play the game
 func Play() {
+
+	var wordsFile string
+	flag.StringVar(&wordsFile, "words_file", "words/words.txt", "Words file")
+	flag.Parse()
+
+	// check if the words file is accessible
+	if _, err := os.Stat(wordsFile); err != nil {
+		log.Fatalf("Could not open the words file: %s\n", err)
+	}
+
 	// Colored messages
 	red := color.New(color.FgRed)
 	green := color.New(color.FgGreen)
 	boldGreen := color.New(color.FgGreen, color.Bold)
 	yellow := color.New(color.FgYellow)
 
-	words := hangman.ReadWordsFromFile("words/words.txt")
+	words := hangman.ReadWordsFromFile(wordsFile)
 	welcomePlayer()
 	choosenWord := hangman.PickWord(words)
 	fmt.Println("Your word has", len(choosenWord), "letters")


### PR DESCRIPTION
## Proposed changes
This PR adds a command line option to specify the word list to use in the game. When starting the CLI/API version you can now pass the `-words_file=/path/to/file.txt` option to load the words from the file. The default file remains `words/words.txt`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mauricioabreu/go-hangman/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
